### PR TITLE
Created a customized button component using the MUI Button

### DIFF
--- a/client/src/components/CustomButton/CustomButton.module.scss
+++ b/client/src/components/CustomButton/CustomButton.module.scss
@@ -1,0 +1,15 @@
+.CustomButton {
+        border-radius:  5px;
+        background-color: #fb7111; //color of our logo
+        height: 50%;
+        width: 100%;
+        cursor: pointer;
+        font-weight: bold;
+        font-size: 20px;
+        color: white;
+
+        &:hover {
+                background-color: #e1660e;
+        }
+}
+  

--- a/client/src/components/CustomButton/CustomButton.tsx
+++ b/client/src/components/CustomButton/CustomButton.tsx
@@ -1,0 +1,36 @@
+import styles from './CustomButton.module.scss';
+import { Button, ButtonProps } from '@mui/material';
+import { styled } from '@mui/system';
+
+/***
+ * Parameters for the custom Button
+ */
+interface CustomButtonProps extends Omit<ButtonProps, 'onClick'> {
+    /**
+     * Function to be completed when the button is clicked.
+     */
+    onClick: () => void;
+    /** The contents in between the CustomButton tags to be displayed in the button. */
+    children: React.ReactNode;
+}
+
+//This allows custom styling of the MUI Button component 
+const StyledButton = styled(Button)()
+
+/***
+ * Creates a custom button
+ */
+const CustomButton: React.FC<CustomButtonProps> = ({onClick, children}: CustomButtonProps ) => {
+    return (
+        <div>
+            <StyledButton 
+                className={styles['CustomButton']}
+                onClick={onClick}
+            >
+                {children} {/* Render children */}
+            </StyledButton>
+        </div>
+    );
+};
+
+export default CustomButton;

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as Navbar } from './Navbar/Navbar';
 export { default as PasswordField } from './PasswordField/PasswordField';
 export { default as TextField } from './TextField/TextField';
 export { default as Loading } from './Loading/Loading';
+export { default as CustomButton } from './CustomButton/CustomButton';


### PR DESCRIPTION
closes #4 
Created a custom button component in order to keep the styling the same throughout the app. 

Example import: 
<img width="329" alt="Screenshot 2024-03-19 at 4 49 13 PM" src="https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/49879221/751d6761-b877-4a99-8bce-57fd9bade5ff">


The color is the orange of the traffic cone from the logo 
<img width="1428" alt="Screenshot 2024-03-19 at 4 14 30 PM" src="https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/49879221/8a62961d-ccd4-4af3-9347-120f9af541d6">

This utilizes the MUI Button component. 
Developer should create a div to customize the sizing of the button. 

It has a required onClick prop that the developer should pass in in order to complete an action. For example, it would be a function that reroutes the app to the desired page. 


The label of the button is the contents that is typed in between the tags. 
<img width="368" alt="Screenshot 2024-03-19 at 4 40 12 PM" src="https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/49879221/79382e7f-8f2b-4fee-9b76-c321e96635b9">
