### PR TITLE
Email Field Component

### DIFF
--- a/client/src/components/EmailField/EmailField.module.scss
+++ b/client/src/components/EmailField/EmailField.module.scss
@@ -1,0 +1,14 @@
+.EmailField {
+    &__container {
+        background-color: white;
+    }
+
+    &__errorText {
+        color: red;
+        background-color: white;
+        padding-top: 0;
+        margin-top: 0;
+        padding-bottom: 0;
+        margin-bottom: 0;
+    }
+}

--- a/client/src/components/EmailField/EmailField.tsx
+++ b/client/src/components/EmailField/EmailField.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import styles from './EmailField.module.scss';
+import TextField from '../TextField/TextField.tsx';
+
+/** 
+ * EmailField Component
+ * Represents a form field for resetting password with email input and basic validation.
+ * This component provides a text field for users to enter their email address and displays
+ * an error message if the entered email format is invalid
+ * 
+*/
+export default function ResetPassword(): JSX.Element {
+    // State to track the validity of the entered email with the format
+    const [isValidEmail, setIsValidEmail] = useState(true);
+
+    /**
+     * handleChange Function
+     * Handles changes in the email input field.
+     * Validates the entered email format.
+     * Updates the isValidEmail state
+     * @param (string) value - the value of the email input field
+     */
+    const handleChange = (value: string) => {
+        // Basic email format validation
+        const isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+        setIsValidEmail(isValid);
+    };
+
+    return (
+        <div className={styles['EmailField__container']}>
+            {/* Email TextField Component */}
+            <TextField
+                header="Email" // Header text for the email input field
+                setInputValue={handleChange} // Handler function to update email input
+                type="email" // Input type for email validation
+            />
+            {/* Display error message if the email format is invalid */}
+            {!isValidEmail && (<p className={styles['EmailField__errorText']}>
+                Invalid email format
+            </p>
+            )}
+        </div>
+    );
+}

--- a/client/src/components/Loading/Loading.tsx
+++ b/client/src/components/Loading/Loading.tsx
@@ -1,10 +1,21 @@
 import styles from './Loading.module.scss';
-import logo from '../../assets/Temp_Roadwatch_logo.svg';
+import logo from '../../assets/Updated_RoadWatch_Logo.svg';
 
+/**
+ * Loading Component
+ * 
+ * Represents a loading indicator displaying the Roadwatch logo.
+ * This component is used to visually indicate that content is being loaded or processed.
+ */
 export default function Loading(): JSX.Element {
   return (
     <div className={styles['Loading__container']}>
-      <img src={logo} alt="Loading indicator displaying the Roadwatch logo." className={styles['Loading__logo']} />
+      {/* Roadwatch Logo */}
+      <img
+        src={logo} // Image source
+        alt="Loading indicator displaying the Roadwatch logo." // Alternate text for accessibility
+        className={styles['Loading__logo']}
+      />
     </div>
   );
 }

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as Navbar } from './Navbar/Navbar';
 export { default as PasswordField } from './PasswordField/PasswordField';
 export { default as TextField } from './TextField/TextField';
 export { default as Loading } from './Loading/Loading';
+export { default as EmailField } from './EmailField/EmailField';


### PR DESCRIPTION
This PR closes #22 

## **Motivation and Context**

This pull request creates the simple `EmailField` component for the mockup reset password page on Figma or for any other use of the email field component in the future. It incorporates the `InputField` component created by @Aligary, and incorporates a popup text underneath in red for an incorrect email format when the user is typing in their email address. I also included the updated `Loading` component from pr #2.

## **Types of Changes**

- [x] Email text field box
- [x] An error message popup for an incorrect email format
- [x] Fixed import library to updated Roadwatch Logo
- [x] Added documentation to `Loading` component

## **Things to Update**

- [ ] Enhanced Validation to check for more complex email patterns
- [ ] Styling updates (especially error popup text in the future)
- [ ] Testing this component
- [ ] Mini logo on left side of the input text box
- [ ] Certain error popup message location 

## **Preview**
![localhost_5173_community (1)](https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/69101935/2b13a19c-63f6-4d8b-8334-400aabd562be)

![localhost_5173_community (4)](https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/69101935/cda2137a-16a4-4bec-a698-4726bc0d7482)


Feedback would be much appreciated. Feel free to add yourself as a reviewer too.