### PR TITLE
ResetPassword component

### DIFF
--- a/client/src/components/ResetPassword/ResetPassword.module.scss
+++ b/client/src/components/ResetPassword/ResetPassword.module.scss
@@ -1,0 +1,89 @@
+$bc: white;
+
+.ResetPassword {
+    &__container {
+        background-color: $bc;
+        display: flex;
+        flex-direction: column;
+        width: auto;
+        height: 100vh;
+    }
+
+    &__protectionDiv {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 9999; // Ensure it's above other content
+        display: none; // Initially hidden
+
+        // Styles for mobile devices
+        @media screen and (max-width: 767px) {
+            display: block; // Show the protection div only on mobile devices
+        }
+    }
+
+    &__buttonContainer {
+        display: flex;
+        justify-content: left;
+        padding-top: 15px;
+    }
+
+    &__logoContainer {
+        display: flex;
+        justify-content: center;
+        width: auto;
+        height: 40vh;
+    }
+
+    &__textContainer {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        padding-bottom: 15px;
+    }
+
+    &__text {
+        font-weight: bold;
+        font-size: 18px;
+        margin: 0;
+    }
+
+    &__text2 {
+        color: #434343;
+        margin: 0;
+        margin-top: 5px;
+        width: 225px;
+        text-align: center;
+    }
+
+    &__textFieldContainer {
+        display: flex;
+        flex-direction: column;
+        padding-bottom: 15px;
+    }
+
+    &__errorText {
+        color: red;
+        background-color: $bc;
+        padding-top: 0;
+        margin-top: 0;
+        padding-bottom: 0;
+        margin-bottom: 0;
+    }
+
+    &__sendButtonContainer {
+        display: flex;
+        width: auto;
+        height: auto;
+        justify-content: center;
+    }
+
+    &__sendButton {
+        width: 100vw;
+        margin-left: 5px;
+        margin-right: 5px;
+    }
+}

--- a/client/src/components/ResetPassword/ResetPassword.tsx
+++ b/client/src/components/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,73 @@
+import { useState, } from 'react';
+import styles from './ResetPassword.module.scss';
+import TextField from '../TextField/TextField.tsx';
+import { Button } from '@mui/material';
+import logo from '../../assets/Updated_RoadWatch_Logo.svg';
+
+/** 
+ * ResetPassword Component
+ * Represents a form field for resetting password with email input and basic validation.
+ * This component provides a text field for users to enter their email address and displays
+ * an error message if the entered email format is invalid.
+ * 
+*/
+export default function ResetPassword(): JSX.Element {
+    // State to track the validity of the entered email with the format
+    const [isValidEmail, setIsValidEmail] = useState(true);
+
+    /**
+     * handleChange Function
+     * Handles changes in the email input field.
+     * Validates the entered email format.
+     * Updates the isValidEmail state
+     * @param (string) value - the value of the email input field
+     */
+    const handleChange = (value: string) => {
+        // Basic email format validation
+        const isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+        setIsValidEmail(isValid);
+    };
+
+    return (
+        <div className={styles['ResetPassword__container']}>
+            <div className={styles['ResetPassword_protectionDiv']} />
+            <div className={styles['ResetPassword__buttonContainer']}>
+                <Button className={styles['ResetPassword__backButton']}>
+                    &lt;
+                </Button>
+            </div>
+            <div className={styles['ResetPassword__logoContainer']}>
+                <img
+                    src={logo}
+                    alt="Displaying logo for reset password page"
+                />
+            </div>
+            <div className={styles['ResetPassword__textContainer']}>
+                <p className={styles['ResetPassword__text']}>
+                    Reset your password
+                </p>
+                <p className={styles['ResetPassword__text2']}>
+                    Enter the email address associated with your account.
+                </p>
+            </div>
+            <div className={styles['ResetPassword__textFieldContainer']}>
+                {/* Email TextField Component */}
+                <TextField
+                    header="Email" // Header text for the email
+                    setInputValue={handleChange}
+                    type="email"
+                />
+                {/* Display error message if the email format is invalid */}
+                {!isValidEmail && (<p className={styles['ResetPassword__errorText']}>
+                    Invalid email format
+                </p>
+                )}
+            </div>
+            <div className={styles['ResetPassword__sendButtonContainer']}>
+                <Button className={styles['ResetPassword__sendButton']}>
+                    SEND
+                </Button>
+            </div>
+        </div >
+    );
+}

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as Navbar } from './Navbar/Navbar';
 export { default as PasswordField } from './PasswordField/PasswordField';
 export { default as TextField } from './TextField/TextField';
 export { default as Loading } from './Loading/Loading';
+export { default as ResetPassword } from './ResetPassword/ResetPassword'


### PR DESCRIPTION
This PR addresses #22 

## **Motivation and Context**

This pull request creates the simple `ResetPassword` component for the mockup reset password page on Figma. It incorporates the `InputField` component created by @Aligary, the new logo created by @morenj, and two Material UI buttons, one for going back a page and the other for sending the message to the email that was inputted. The `ResetPassword` component also incorporates a popup text underneath in red for an incorrect format when the user is typing in their email address. I also included the updated `Loading` component from pr #2.

## **Types of Changes**

- [x] Email text field box
- [x] An error message popup for an incorrect email format
- [x] Fixed import library to updated Roadwatch Logo
- [x] Added new logo onto Reset password component
- [x] Incorporated two Material UI buttons
- [x] Added documentation to `Loading` component

## **Things to Update**

- [ ] Enhanced Validation to check for more complex email patterns
- [ ] Styling updates (Add the custom button @Aligary will create)
- [ ] Testing this component
- [ ] Mini logo on left side of the input text box

## **Preview**
![localhost_5173_community (1)](https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/69101935/2b13a19c-63f6-4d8b-8334-400aabd562be)

![localhost_5173_community (4)](https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/69101935/cda2137a-16a4-4bec-a698-4726bc0d7482)

<img width="318" alt="Screenshot 2024-03-19 at 11 01 47 PM" src="https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/69101935/35ea5a4f-6443-4efa-81bb-58a0cea453e1">



Feedback would be much appreciated. Feel free to add yourself as a reviewer too.