### PR TITLE
Fixed custom button styling

### DIFF
--- a/client/src/components/CustomButton/CustomButton.module.scss
+++ b/client/src/components/CustomButton/CustomButton.module.scss
@@ -1,15 +1,15 @@
 .CustomButton {
         border-radius:  5px;
-        background-color: #fb7111; //color of our logo
+        background-color: #fb7111 !important; //color of our logo
         height: 50%;
         width: 100%;
         cursor: pointer;
-        font-weight: bold;
+        font-weight: bold !important;
         font-size: 20px;
-        color: white;
+        color: white !important;
 
         &:hover {
-                background-color: #e1660e;
+                background-color: #e1660e !important;
         }
 }
   


### PR DESCRIPTION
Closes #47.
Button should now display as orange. 
Fixed the styling by adding `!important` which basically gives that specific style the highest priority. 

Might cause problems if someone wants to change the color of the button. 