### PR TITLE
Create Stepper component for Register Page

### DIFF
--- a/client/src/components/CreateAccount/CreateAccount.tsx
+++ b/client/src/components/CreateAccount/CreateAccount.tsx
@@ -1,16 +1,21 @@
 import styles from './CreateAccount.module.scss';
 import { useState } from 'react';
 import { IconButton, Typography, AppBar, Toolbar, Box, Stack } from '@mui/material';
+import { Stepper, Step, StepLabel } from '@mui/material';
 import { ArrowBackIos } from '@mui/icons-material';
 import { CustomButton, PasswordField } from '@/components';
 
 interface CreateAccountProps {
+  currentStep: number;
+  steps: string[];
   updateData: (field: string, value: string) => void;
   handleBack: () => void;
   handleSubmit: () => void;
 }
 
 export default function CreateAccount({
+  currentStep,
+  steps,
   updateData,
   handleBack,
   handleSubmit,
@@ -46,6 +51,15 @@ export default function CreateAccount({
             </Typography>
           </Toolbar>
         </AppBar>
+
+        <Stepper activeStep={currentStep} alternativeLabel>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+
         <Stack spacing={2}>
           <PasswordField header="Password" setInputValue={setPassword} />
           <PasswordField header="Confirm Password" setInputValue={setConfirmPassword} />

--- a/client/src/components/SignUp/GeneralInfo/GeneralInfo.tsx
+++ b/client/src/components/SignUp/GeneralInfo/GeneralInfo.tsx
@@ -1,14 +1,22 @@
 import styles from './GeneralInfo.module.scss';
 import { useState } from 'react';
 import { Box, Stack, Typography } from '@mui/material';
+import { Stepper, Step, StepLabel } from '@mui/material';
 import { TextField, CustomButton } from '@/components';
 
 interface GeneralInfoProps {
+  currentStep: number;
+  steps: string[];
   updateData: (field: string, value: string) => void;
   handleSubmit: () => void;
 }
 
-function GeneralInfo({ updateData, handleSubmit }: GeneralInfoProps): JSX.Element {
+function GeneralInfo({
+  currentStep,
+  steps,
+  updateData,
+  handleSubmit,
+}: GeneralInfoProps): JSX.Element {
   // State variables to store form input values
   const [firstName, setFirstName] = useState<string>('');
   const [lastName, setLastName] = useState<string>('');
@@ -40,6 +48,14 @@ function GeneralInfo({ updateData, handleSubmit }: GeneralInfoProps): JSX.Elemen
         <Typography variant="h4" gutterBottom align="center" sx={{ paddingBottom: '20px' }}>
           General Info
         </Typography>
+
+        <Stepper activeStep={currentStep} alternativeLabel>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
 
         <Stack spacing={2}>
           {/* Text fields for user input */}

--- a/client/src/components/SignUp/SignUp.tsx
+++ b/client/src/components/SignUp/SignUp.tsx
@@ -2,16 +2,25 @@ import styles from './SignUp.module.scss';
 import { useState } from 'react';
 
 import { AppBar, Toolbar, IconButton, Stack, Box, Typography } from '@mui/material';
+import { Stepper, Step, StepLabel } from '@mui/material';
 import { ArrowBackIos } from '@mui/icons-material';
 import { TextField, CustomButton } from '@/components';
 
 interface SignUpProps {
+  currentStep: number;
+  steps: string[];
   updateData: (field: string, value: string) => void;
   handleBack: () => void;
   handleSubmit: () => void;
 }
 
-export default function SignUp({ updateData, handleBack, handleSubmit }: SignUpProps): JSX.Element {
+export default function SignUp({
+  currentStep,
+  steps,
+  updateData,
+  handleBack,
+  handleSubmit,
+}: SignUpProps): JSX.Element {
   const [address, setAddressValue] = useState<string>('');
   const [city, setCityValue] = useState<string>('');
   const [state, setStateValue] = useState<string>('');
@@ -47,6 +56,14 @@ export default function SignUp({ updateData, handleBack, handleSubmit }: SignUpP
             </Typography>
           </Toolbar>
         </AppBar>
+
+        <Stepper activeStep={currentStep} alternativeLabel>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
 
         {/* create the input fields and the titles for the fields */}
         <Stack spacing={2}>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -37,7 +37,7 @@ const router = createBrowserRouter([
     element: <Instructions />,
   },
   {
-    path: '/register/*',
+    path: '/register/',
     element: <Register />,
   },
 ]);

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -1,11 +1,9 @@
 import styles from './Register.module.scss';
 import { GeneralInfo, SignUp, CreateAccount } from '@/components';
-import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
-const steps = ['General Info', 'Location', 'Create Account'];
-
 export default function Register(): JSX.Element {
+  const steps = ['General Info', 'Location', 'Create Account'];
   const [currentStep, setCurrentStep] = useState(0);
   const [formData, setFormData] = useState({
     firstName: '',
@@ -22,8 +20,6 @@ export default function Register(): JSX.Element {
     confirmPassword: '',
   });
 
-  const navigate = useNavigate();
-
   const updateFormData = (field: string, value: string) => {
     setFormData((prevData) => ({
       ...prevData,
@@ -31,70 +27,63 @@ export default function Register(): JSX.Element {
     }));
   };
 
-  const handleSubmitGeneralInfo = () => {
-    navigate('/register/sign-up');
+  const handleNext = () => {
     setCurrentStep((prevStep) => prevStep + 1);
   };
 
-  const handleBackSignUp = () => {
-    navigate('/register');
+  const handleBack = () => {
     setCurrentStep((prevStep) => prevStep - 1);
   };
 
-  const handleSubmitSignUp = () => {
-    navigate('/register/create-account');
-    setCurrentStep((prevStep) => prevStep + 1);
-  };
-
-  const handleBackCreateAccount = () => {
-    navigate('/register/sign-up');
-    setCurrentStep((prevStep) => prevStep - 1);
-  };
-
-  const handleSubmitCreateAccount = () => {
-    setCurrentStep((prevStep) => prevStep + 1);
+  const handleCreateAccount = () => {
+    // TODO: Create the User
     console.log(formData);
+    return 'Account Created';
+  };
+
+  const getStepContent = () => {
+    switch (currentStep) {
+      case 0:
+        return (
+          <GeneralInfo
+            currentStep={currentStep}
+            steps={steps}
+            updateData={updateFormData}
+            handleSubmit={handleNext}
+          />
+        );
+      case 1:
+        return (
+          <SignUp
+            currentStep={currentStep}
+            steps={steps}
+            updateData={updateFormData}
+            handleBack={handleBack}
+            handleSubmit={handleNext}
+          />
+        );
+      case 2:
+        return (
+          <CreateAccount
+            currentStep={currentStep}
+            steps={steps}
+            updateData={updateFormData}
+            handleBack={handleBack}
+            handleSubmit={handleNext}
+          />
+        );
+      default:
+        return;
+    }
   };
 
   return (
     <div className={styles['Register']}>
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <GeneralInfo
-              currentStep={currentStep}
-              steps={steps}
-              updateData={updateFormData}
-              handleSubmit={handleSubmitGeneralInfo}
-            />
-          }
-        />
-        <Route
-          path="/sign-up"
-          element={
-            <SignUp
-              currentStep={currentStep}
-              steps={steps}
-              updateData={updateFormData}
-              handleBack={handleBackSignUp}
-              handleSubmit={handleSubmitSignUp}
-            />
-          }
-        />
-        <Route
-          path="/create-account"
-          element={
-            <CreateAccount
-              currentStep={currentStep}
-              steps={steps}
-              updateData={updateFormData}
-              handleBack={handleBackCreateAccount}
-              handleSubmit={handleSubmitCreateAccount}
-            />
-          }
-        />
-      </Routes>
+      {currentStep === steps.length ? (
+        <div>{handleCreateAccount()}</div>
+      ) : (
+        <div>{getStepContent()}</div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -1,10 +1,13 @@
 import styles from './Register.module.scss';
 import { GeneralInfo, SignUp, CreateAccount } from '@/components';
 import { Route, Routes, useNavigate } from 'react-router-dom';
+import { Stepper, Step, StepLabel } from '@mui/material';
 import { useState } from 'react';
 
+const steps = ['General Info', 'Location', 'Create Account'];
+
 export default function Register(): JSX.Element {
-  const navigate = useNavigate();
+  const [currentStep, setCurrentStep] = useState(0);
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
@@ -20,6 +23,8 @@ export default function Register(): JSX.Element {
     confirmPassword: '',
   });
 
+  const navigate = useNavigate();
+
   const updateFormData = (field: string, value: string) => {
     setFormData((prevData) => ({
       ...prevData,
@@ -29,26 +34,38 @@ export default function Register(): JSX.Element {
 
   const handleSubmitGeneralInfo = () => {
     navigate('/register/sign-up');
+    setCurrentStep((prevStep) => prevStep + 1);
   };
 
   const handleBackSignUp = () => {
     navigate('/register');
+    setCurrentStep((prevStep) => prevStep - 1);
   };
 
   const handleSubmitSignUp = () => {
     navigate('/register/create-account');
+    setCurrentStep((prevStep) => prevStep + 1);
   };
 
   const handleBackCreateAccount = () => {
     navigate('/register/sign-up');
+    setCurrentStep((prevStep) => prevStep - 1);
   };
 
   const handleSubmitCreateAccount = () => {
+    setCurrentStep((prevStep) => prevStep + 1);
     console.log(formData);
   };
 
   return (
     <div className={styles['Register']}>
+      <Stepper activeStep={currentStep} alternativeLabel>
+        {steps.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
       <Routes>
         <Route
           path="/"

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -1,7 +1,6 @@
 import styles from './Register.module.scss';
 import { GeneralInfo, SignUp, CreateAccount } from '@/components';
 import { Route, Routes, useNavigate } from 'react-router-dom';
-import { Stepper, Step, StepLabel } from '@mui/material';
 import { useState } from 'react';
 
 const steps = ['General Info', 'Location', 'Create Account'];
@@ -59,24 +58,24 @@ export default function Register(): JSX.Element {
 
   return (
     <div className={styles['Register']}>
-      <Stepper activeStep={currentStep} alternativeLabel>
-        {steps.map((label) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        ))}
-      </Stepper>
       <Routes>
         <Route
           path="/"
           element={
-            <GeneralInfo updateData={updateFormData} handleSubmit={handleSubmitGeneralInfo} />
+            <GeneralInfo
+              currentStep={currentStep}
+              steps={steps}
+              updateData={updateFormData}
+              handleSubmit={handleSubmitGeneralInfo}
+            />
           }
         />
         <Route
           path="/sign-up"
           element={
             <SignUp
+              currentStep={currentStep}
+              steps={steps}
               updateData={updateFormData}
               handleBack={handleBackSignUp}
               handleSubmit={handleSubmitSignUp}
@@ -87,6 +86,8 @@ export default function Register(): JSX.Element {
           path="/create-account"
           element={
             <CreateAccount
+              currentStep={currentStep}
+              steps={steps}
               updateData={updateFormData}
               handleBack={handleBackCreateAccount}
               handleSubmit={handleSubmitCreateAccount}


### PR DESCRIPTION
## Description
This PR introduces a basic "Stepper" component for the register page.

## Related Issue
Closes #102.

## Type of Changes
Please select the relevant option:
- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Other (please specify)
      
In addition to the stepper component, this PR slightly modifies the register page to display each component based on the current step, rather than routing to a separate page each time.

## Things to Update
Please add any features, buttons, or pages that might need updating in the future:
- [ ] Button Functunality 
- [ ] Code Documentation 
- [ ] Mobile Responsiveness 
- [ ] Code testing 
- [x] Other (please specify)

Currently, the "create account" button will log all the data which the user input during the registration process. This button's functionality is determined by the `handleCreateAccount` function:
```ts
  const handleCreateAccount = () => {
    // TODO: Create the User
    console.log(formData);
    return 'Account Created';
  };
```

In the future this should create the account, then additionally go to the relevant page afterwards (home page, etc.)

## Screenshots 
Here's a gif which shows basic functionality. For demonstration purposes, I have disabled the checks for required fields.
![register_stepper](https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/105743189/4bedbb1a-e11e-4d3c-afdf-6cdfb89a56b5)


## Additional Notes
In order to have the stepper display within each component, I created a stepper component within GeneralInfo.tsx, SignUp.tsx, and CreateAccount.tsx. A cleaner way to do this would be to have just one stepper in Register.tsx but I was unable to cleanly fit it inside the white container defined in each component.

Some future eye-candy might include a carousel-like component. 
