### PR TITLE
Added post component

### DIFF
--- a/client/src/components/CommunityPost/CommunityPost.module.scss
+++ b/client/src/components/CommunityPost/CommunityPost.module.scss
@@ -1,0 +1,39 @@
+.CommunityPost{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    &__card{
+        width: 384px;
+        margin: 16px;
+    }
+    &__contentContainer{
+        max-height: 2000px;
+    }
+    &__header{
+        display: flex;
+        padding-bottom: 10px;
+        justify-content: space-between;
+        align-items: center;
+    }
+    &__markerIcon{
+        padding-right: 10px;
+    }
+    &__textBody{ 
+        max-height: 6.5em;
+        overflow-y: auto;
+    }
+    &__headerLeft{
+        display: flex;
+        align-items: center;
+    }
+    &__headerRight{
+        display: flex;
+    }
+    &__bodyPreview{
+        display: flex;
+        justify-content: center;
+        max-height: 6.5em;
+        padding-bottom: 10px;
+    }
+
+}

--- a/client/src/components/CommunityPost/CommunityPost.module.scss
+++ b/client/src/components/CommunityPost/CommunityPost.module.scss
@@ -16,6 +16,9 @@
         align-items: center;
     }
     &__markerIcon{
+        max-width: 100%;
+        width: 50px; 
+        height: auto;
         padding-right: 10px;
     }
     &__textBody{ 
@@ -34,6 +37,11 @@
         justify-content: center;
         max-height: 6.5em;
         padding-bottom: 10px;
+    }
+    &__markerBodyPreview{
+        max-width: 100%;
+        width: 100px; 
+        height: auto;
     }
 
 }

--- a/client/src/components/CommunityPost/CommunityPost.tsx
+++ b/client/src/components/CommunityPost/CommunityPost.tsx
@@ -68,7 +68,6 @@ const CommunityPost: React.FC<CommunityPostProps> = ({isMarker, content, user, m
             break;
         default:
             markerIcon = Cone;
-            break;
     }
 
     return (
@@ -81,7 +80,7 @@ const CommunityPost: React.FC<CommunityPostProps> = ({isMarker, content, user, m
                             <div className={styles['CommunityPost__header']}>
                                 <div className={styles['CommunityPost__headerLeft']}>
                                     {isMarker ? (
-                                        <img className={styles['CommunityPost__markerIcon']} height={"50px"} src={markerIcon} alt={"Marker Type"}/>
+                                        <img className={styles['CommunityPost__markerIcon']} src={markerIcon} alt="Marker Type"/>
                                         ) : (
                                             null
                                         )
@@ -98,7 +97,7 @@ const CommunityPost: React.FC<CommunityPostProps> = ({isMarker, content, user, m
                             <div className={styles['CommunityPost__bodyPreview']}>
                                 {isMarker ? (   
                                     // This is the preview of a marker post
-                                    <img src={Logo} height={"100px"} alt="Roadwatch Logo" />
+                                    <img src={Logo} className={styles['CommunityPost__markerBodyPreview']} alt="Roadwatch Logo" />
                                 ) : ( 
                                     // This is the preview of a text post
                                     <StyledTypography variant="body2" color="text.secondary" className={styles['CommunityPost__textBody']}>

--- a/client/src/components/CommunityPost/CommunityPost.tsx
+++ b/client/src/components/CommunityPost/CommunityPost.tsx
@@ -1,0 +1,123 @@
+import styles from './CommunityPost.module.scss';
+import { Card, CardContent, Typography, Avatar} from '@mui/material';
+import { CustomButton } from "@/components";
+import { styled } from '@mui/system';
+import Cone from '../../assets/markers/Cone.svg';
+import CarAccident from '../../assets/markers/CarAccident.svg';
+import Pothole from '../../assets/markers/Pothole.svg';
+import RoadDamage from '../../assets/markers/RoadDamage.svg';
+import WarningSign from '../../assets/markers/WarningSign.svg';
+import Logo from '../../assets/Updated_RoadWatch_Logo.svg';
+
+/** Parameters for the CommunityPost */
+interface CommunityPostProps {
+    /** Boolean which tells if its a marker post or text post*/
+    isMarker: boolean;
+    /** Content of the post, Title and Body */
+    content: Content;
+    /** User information of post creater */
+    user: string; //change this to our user. 
+    /** If marker post, pass in the marker information */
+    marker?: Marker;
+}
+
+/** Marker model */
+interface Marker {
+    longitude: number;
+    latitude: number;
+    type: string;
+}
+
+/** Content model */
+interface Content {
+    /** String of the Title of the post */
+    title: string;
+    /** String of the body of the post*/
+    body: string;
+}
+
+/** This allows custom styling of the MUI Typography component 
+ *  Specifically, the body text preview.
+*/
+const StyledTypography = styled(Typography)()
+
+/** Creates a CommunityPost component */
+const CommunityPost: React.FC<CommunityPostProps> = ({isMarker, content, user, marker}: CommunityPostProps )  => {
+    /** OnClick function to view post
+     *  Need to update so that the full post is shown when this is called
+    */
+    const viewPost = ()=> {
+        console.log("View Post")
+    }
+    const {title, body} = content;
+
+    //Variable to store marker icon
+    let markerIcon=""
+    switch (marker?.type) {
+        case 'CarAccident':
+            markerIcon = CarAccident;
+            break;
+        case 'pothole':
+            markerIcon = Pothole;
+            break;
+        case 'RoadDamage':
+            markerIcon = RoadDamage;
+            break;
+        case 'WarningSign':
+            markerIcon = WarningSign;
+            break;
+        default:
+            markerIcon = Cone;
+            break;
+    }
+
+    return (
+        <div className={styles['CommunityPost']}>
+            {/* // ai-gen start (ChatGPT-3.5, 2) */}
+            <div className={styles['CommunityPost__card']}>
+                <Card>
+                    <div>
+                        <CardContent className={styles['CommunityPost__contentContainer']}>
+                            <div className={styles['CommunityPost__header']}>
+                                <div className={styles['CommunityPost__headerLeft']}>
+                                    {isMarker ? (
+                                        <img className={styles['CommunityPost__markerIcon']} height={"50px"} src={markerIcon} alt={"Marker Type"}/>
+                                        ) : (
+                                            null
+                                        )
+                                    }
+                                    <Typography variant="h5" component="h2">
+                                        {title}
+                                    </Typography>
+                                </div>
+                                <div className={styles['CommunityPost__headerRight']}>
+                                    {/* Replace with user profile */}
+                                    <Avatar>{user}</Avatar> 
+                                </div>
+                            </div>
+                            <div className={styles['CommunityPost__bodyPreview']}>
+                                {isMarker ? (   
+                                    // This is the preview of a marker post
+                                    <img src={Logo} height={"100px"} alt="Roadwatch Logo" />
+                                ) : ( 
+                                    // This is the preview of a text post
+                                    <StyledTypography variant="body2" color="text.secondary" className={styles['CommunityPost__textBody']}>
+                                        {body}
+                                    </StyledTypography>
+                                )}
+                            </div>
+                            <div>
+                                <CustomButton onClick={viewPost}>
+                                    View Post
+                                </CustomButton>
+                            </div>
+                        </CardContent>
+                    </div>
+                </Card>
+            </div>
+            {/* // ai-gen end */}
+        </div>
+    );
+};
+
+export default CommunityPost;

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -13,3 +13,4 @@ export { default as EnableNotification } from './EnableNotification/EnableNotifi
 export { default as CreateAccount } from './CreateAccount/CreateAccount';
 export { default as SignUp } from './SignUp/SignUp';
 export { default as GeneralInfo } from './SignUp/GeneralInfo/GeneralInfo';
+export { default as CommunityPost } from './CommunityPost/CommunityPost';


### PR DESCRIPTION
## Description
Creates the Post component

## Related Issue
Closes #36 

## Type of Changes
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please specify)
      
This PR adds the component that previews posts in a community. There are two types of posts. Both posts have Titles, User, and View post button

- Marker Post: It has the marker icon in the header and the RoadWatch logo (We can replace this with the actual location of the marker, but decided to omit this to reduce api calls) 
<img width="425" alt="Screenshot 2024-04-04 at 4 35 40 PM" src="https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/49879221/65c2b742-3f68-4d5f-8ca4-9aa833ad10fe">


- Text Post: It displays the body of the post. 
<img width="423" alt="Screenshot 2024-04-04 at 4 35 32 PM" src="https://github.com/UNLV-CS472-672/2024-S-GROUP1-Roadwatch/assets/49879221/44aa3e60-48fc-4feb-943c-b405b6247375">

## Things to Update
- [x] Button Functunality 
- The View Post button currently only displays text to the console. It will need to be updated to show the full post. 

- [ ] Code Documentation 
- [ ] Mobile Responsiveness 
- [x] Code testing 
- [x] Other (please specify)
- user Avatar with the users actual Avatar. 
- Display of Marker on the map

## Additional Notes
This component was made with assumptions of how the Post Data Model (#48) will be set up. I can go back and add/fix anything that doesn't line up. 

## AI-Usage
I used chatGPT to help me create the Post component outline. Here is that conversation: https://chat.openai.com/share/c08923f2-f346-4f75-a701-32493ae2bd22 
