### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request-or-bug-fix.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-or-bug-fix.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request or Bug Fix
+about: Suggest an enhancement for this project or a bug that needs to be fixed.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Summary
+[Provide a brief, nontechnical overview of the feature you want to implement or the bug you want to fix]
+
+# Technical Details
+[Explain the technologies the assignee will need to use, the files they'll likely have to touch, etc. You should also state whether this is a frontend or backend issue (it can be both)]
+
+# Acceptance Criteria
+[Create a bulleted list or check list of all the things that *must* be completed in order for this issue to be considered completed]
+
+# Figma
+[**Optional:** If this is a feature request, take a picture of the corresponding feature on our Figma document. Other relevant screenshots are welcome]


### PR DESCRIPTION
This is a quick PR that introduces an issue template for our team. We can use this template moving forward to more easily document and categorize our issues. It also forces us to be more granular about the changes we want to implement so there isn't further miscommunication about responsibilities. 